### PR TITLE
feat:#17: 공연 도메인, Persist 설계

### DIFF
--- a/app/src/main/java/com/picketing/www/business/domain/Show.java
+++ b/app/src/main/java/com/picketing/www/business/domain/Show.java
@@ -1,0 +1,20 @@
+package com.picketing.www.business.domain;
+
+import com.picketing.www.business.type.Genre;
+import com.picketing.www.business.type.SubGenre;
+
+import java.time.LocalDateTime;
+
+public class Show {
+
+    private Long id;
+    private String title;
+    private Genre genre;
+    private SubGenre subGenre;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private String venue;
+    private Long runningTime;
+    private Long intermission;
+    private String details;
+}

--- a/app/src/main/java/com/picketing/www/business/domain/ShowFactory.java
+++ b/app/src/main/java/com/picketing/www/business/domain/ShowFactory.java
@@ -1,0 +1,7 @@
+package com.picketing.www.business.domain;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class ShowFactory {
+}

--- a/app/src/main/java/com/picketing/www/business/domain/ShowFactory.java
+++ b/app/src/main/java/com/picketing/www/business/domain/ShowFactory.java
@@ -1,7 +1,0 @@
-package com.picketing.www.business.domain;
-
-import org.springframework.stereotype.Component;
-
-@Component
-public class ShowFactory {
-}

--- a/app/src/main/java/com/picketing/www/business/type/AgeGroup.java
+++ b/app/src/main/java/com/picketing/www/business/type/AgeGroup.java
@@ -1,0 +1,21 @@
+package com.picketing.www.business.type;
+
+import lombok.Getter;
+
+@Getter
+public enum AgeGroup {
+
+    ALL(0, "전체 관람가"),
+    SEVEN(7, "만 7세 이상 관람가"),
+    NINE(9, "만 9세 이상 관람가"),
+    FOURTEEN(14, "만 14세 이상 관람가"),
+    NINETEEN(19, "만 19세 이상 관람가");
+
+    private final int minimumAge;
+    private final String details;
+
+    AgeGroup(int minimumAge, String details) {
+        this.minimumAge = minimumAge;
+        this.details = details;
+    }
+}

--- a/app/src/main/java/com/picketing/www/business/type/Genre.java
+++ b/app/src/main/java/com/picketing/www/business/type/Genre.java
@@ -1,0 +1,24 @@
+package com.picketing.www.business.type;
+
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Getter
+public enum Genre {
+
+    CONCERT("콘서트", Arrays.asList(SubGenre.DOMESTIC, SubGenre.FOREIGN, SubGenre.FESTIVAL)),
+    MUSICAL("뮤지컬", Arrays.asList(SubGenre.ORIGINAL, SubGenre.LICENSE, SubGenre.CREATIVE, SubGenre.NONVERBAL)),
+    PLAY("연극", Arrays.asList(SubGenre.PLAY)),
+    SPORT("스포츠", Arrays.asList(SubGenre.BASEBALL, SubGenre.FOOTBALL, SubGenre.ESPORTS));
+
+    private final String genre;
+
+    private final List<SubGenre> subGenre;
+
+    Genre(String genre, List<SubGenre> subGenre) {
+        this.genre = genre;
+        this.subGenre = subGenre;
+    }
+}

--- a/app/src/main/java/com/picketing/www/business/type/SubGenre.java
+++ b/app/src/main/java/com/picketing/www/business/type/SubGenre.java
@@ -1,0 +1,28 @@
+package com.picketing.www.business.type;
+
+import lombok.Getter;
+
+@Getter
+public enum SubGenre {
+
+    DOMESTIC("국내뮤지션"),
+    FOREIGN("해외뮤지션"),
+    FESTIVAL("페스티벌"),
+
+    ORIGINAL("오리지널"),
+    LICENSE("라이센스"),
+    CREATIVE("창작"),
+    NONVERBAL("넌버벌"),
+
+    PLAY("연극전체"),
+
+    BASEBALL("야구"),
+    FOOTBALL("축구"),
+    ESPORTS("E스포츠");
+
+    private final String subGenre;
+
+    SubGenre(String subGenre) {
+        this.subGenre = subGenre;
+    }
+}

--- a/app/src/main/java/com/picketing/www/persistence/table/ShowPersist.java
+++ b/app/src/main/java/com/picketing/www/persistence/table/ShowPersist.java
@@ -1,0 +1,20 @@
+package com.picketing.www.persistence.table;
+
+import com.picketing.www.business.type.Genre;
+import com.picketing.www.business.type.SubGenre;
+
+import java.time.LocalDateTime;
+
+public record ShowPersist(
+        Long id,
+        String title,
+        Genre genre,
+        SubGenre subGenre,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        String venue,
+        Long runningTime,
+        Long intermission,
+        String details
+) {
+}


### PR DESCRIPTION
## 관련된 이슈 번호
- issue : #17 

## 변경사항 (할 일)
- [X] 공연 도메인을 설계하였습니다
    - `Show` : 공연 도메인
   - `Genre` : 공연의 장르를 저장하는 Enum 타입 (콘서트 / 뮤지컬 / 연극 / 스포츠 등)
   - `SubGenre` : 공연의 세부 장르를 저장하는 Enum 타입
       - 콘서트 내 세부 장르 -> 국내 뮤지션 / 해외 뮤지션 / 페스티벌
       - 뮤지컬 내 세부 장르 -> 오리지널(내한공연) / 라이센스 / 창작 / 넌버벌
       - 연극 내 세부 장르 -> 없음 (연극 전체)
       - 스포츠 내 세부 장르 -> 야구 / 축구 / E스포츠
    - `AgeGroup` : 공연의 관람 연령 정보를 담는 Enum 타입
    - 공연의 id를 사용하는 부분이 많을 것 같아서 `ShowPersist`와 마찬가지로 `id`를 추가하였습니다
   
## 추가 점검사항
