### PR TITLE
[Feature] User 도메인에도 id를 추가하며 관련 로직 수정

### DIFF
--- a/app/src/main/java/com/picketing/www/application/interceptor/LoginCheckInterceptor.java
+++ b/app/src/main/java/com/picketing/www/application/interceptor/LoginCheckInterceptor.java
@@ -16,9 +16,9 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws
 		Exception {
 		HttpSession session = request.getSession();
-		String userEmail = (String)session.getAttribute("login_user");
+		Long userId = (Long)session.getAttribute("login_user");
 
-		if (userEmail == null || userEmail.isEmpty()) {
+		if (userId == null || userId == 0L) {
 			throw new CustomException(ErrorCode.UNAUTHORIZED);
 		}
 		return true;

--- a/app/src/main/java/com/picketing/www/business/domain/User.java
+++ b/app/src/main/java/com/picketing/www/business/domain/User.java
@@ -10,6 +10,8 @@ import com.picketing.www.application.exception.ErrorCode;
 import lombok.Builder;
 
 public class User {
+
+	final Long id;
 	final String email;
 	final String name;
 	final String phoneNumber;
@@ -18,8 +20,9 @@ public class User {
 	String password;
 
 	@Builder
-	User(String email, String password, String name, String phoneNumber, LocalDateTime createdAt,
+	User(Long id, String email, String password, String name, String phoneNumber, LocalDateTime createdAt,
 		LocalDateTime modifiedAt) {
+		this.id = id;
 		this.email = email;
 		this.password = password;
 		this.name = name;
@@ -48,5 +51,9 @@ public class User {
 
 	public boolean match(User loginUser) {
 		return loginUser.password.equals(this.password);
+	}
+
+	public Long getId() {
+		return this.id;
 	}
 }

--- a/app/src/main/java/com/picketing/www/business/domain/UserFactory.java
+++ b/app/src/main/java/com/picketing/www/business/domain/UserFactory.java
@@ -12,14 +12,16 @@ import com.picketing.www.presentation.dto.response.user.UserSignInResponse;
 
 @Component
 public class UserFactory {
+
 	public User create(UserPersist userPersist) {
 		return User.builder()
-			.email(userPersist.email())
-			.password(userPersist.password())
-			.name(userPersist.name())
-			.phoneNumber(userPersist.phoneNumber())
-			.createdAt(userPersist.createdAt())
-			.modifiedAt(userPersist.modifiedAt())
+			.id(userPersist.getId())
+			.email(userPersist.getEmail())
+			.password(userPersist.getPassword())
+			.name(userPersist.getName())
+			.phoneNumber(userPersist.getPhoneNumber())
+			.createdAt(userPersist.getCreatedAt())
+			.modifiedAt(userPersist.getModifiedAt())
 			.build();
 	}
 

--- a/app/src/main/java/com/picketing/www/business/service/UserService.java
+++ b/app/src/main/java/com/picketing/www/business/service/UserService.java
@@ -47,7 +47,7 @@ public class UserService {
 			throw new CustomException(ErrorCode.INVALID_PASSWORD);
 		}
 
-		httpSession.setAttribute(SESSION_LOGIN_USER, loginUser.getEmail());
+		httpSession.setAttribute(SESSION_LOGIN_USER, loginUser.getId());
 
 		return loginUser;
 	}

--- a/app/src/main/java/com/picketing/www/persistence/repository/UserRepository.java
+++ b/app/src/main/java/com/picketing/www/persistence/repository/UserRepository.java
@@ -23,16 +23,17 @@ public class UserRepository {
 
 	public Long save(UserPersist userPersist) {
 		long id = sequence.get();
+		userPersist.createUserPersist(id);
 		store.put(id, userPersist);
 		sequence.set(id + 1);
-		userEmailIndex.put(userPersist.email(), userPersist);
+		userEmailIndex.put(userPersist.getEmail(), userPersist);
 
 		return id;
 	}
 
 	public Boolean existByEmail(String email) {
 		for (Map.Entry<Long, UserPersist> userPersistEntry : store.entrySet()) {
-			if (email.equals(userPersistEntry.getValue().email())) {
+			if (email.equals(userPersistEntry.getValue().getEmail())) {
 				return true;
 			}
 		}

--- a/app/src/main/java/com/picketing/www/persistence/table/UserPersist.java
+++ b/app/src/main/java/com/picketing/www/persistence/table/UserPersist.java
@@ -3,14 +3,22 @@ package com.picketing.www.persistence.table;
 import java.time.LocalDateTime;
 
 import lombok.Builder;
+import lombok.Getter;
 
 @Builder
-public record UserPersist(
-	String email,
-	String password,
-	String name,
-	String phoneNumber,
-	LocalDateTime createdAt,
-	LocalDateTime modifiedAt
-) {
+@Getter
+public class UserPersist {
+	Long id;
+	String email;
+	String password;
+	String name;
+	String phoneNumber;
+	LocalDateTime createdAt;
+	LocalDateTime modifiedAt;
+
+	// FIXME JPA 전환 완료 시, 아래 함수 삭제 및 UserPersist 다시 record로 변경
+	public UserPersist createUserPersist(Long id) {
+		this.id = id;
+		return this;
+	}
 }

--- a/app/src/test/java/com/picketing/www/application/interceptor/LoginCheckInterceptorTest.java
+++ b/app/src/test/java/com/picketing/www/application/interceptor/LoginCheckInterceptorTest.java
@@ -71,7 +71,7 @@ class LoginCheckInterceptorTest {
 			LoginCheckInterceptor interceptor = new LoginCheckInterceptor();
 
 			// given
-			session.setAttribute("login_user", "qwerty1234@gmail.com");
+			session.setAttribute("login_user", 1L);
 			request.setSession(session);
 
 			// when
@@ -92,7 +92,7 @@ class LoginCheckInterceptorTest {
 			MockHttpSession session = new MockHttpSession();
 			LoginCheckInterceptor interceptor = new LoginCheckInterceptor();
 			// given
-			session.setAttribute("login_user", "qwerty1234@gmail.com");
+			session.setAttribute("login_user", 1L);
 			request.setSession(session);
 			Assertions.assertThat(interceptor.preHandle(request, response, null)).isTrue();
 

--- a/app/src/test/java/com/picketing/www/presentation/controller/user/UserControllerTest.java
+++ b/app/src/test/java/com/picketing/www/presentation/controller/user/UserControllerTest.java
@@ -55,14 +55,15 @@ class UserControllerTest {
 		@DisplayName("200:존재하는 데이터 정상 조회")
 		void success() throws Exception {
 			Mockito.when(userRepository.findById(anyLong()))
-				.thenReturn(new UserPersist(
-						"test@email.com",
-						"1234567890",
-						"testUser",
-						"01012345678",
-						LocalDateTime.now(),
-						LocalDateTime.now()
-					)
+				.thenReturn(UserPersist.builder()
+					.id(1L)
+					.email("test@email.com")
+					.password("1234567890")
+					.name("testUser")
+					.phoneNumber("01012345678")
+					.createdAt(LocalDateTime.now())
+					.modifiedAt(LocalDateTime.now())
+					.build()
 				);
 			mockMvc.perform(MockMvcRequestBuilders
 					.get(BASE_PATH + "/1")
@@ -190,14 +191,15 @@ class UserControllerTest {
 				.thenReturn("1234567890");
 			Mockito.when(userRepository.findByEmail(Mockito.anyString()))
 				.thenReturn(
-					Optional.of(new UserPersist(
-							"test@email.com",
-							"1234567890",
-							"testUser",
-							"01012345678",
-							LocalDateTime.now(),
-							LocalDateTime.now()
-						)
+					Optional.of(UserPersist.builder()
+						.id(1L)
+						.email("test@email.com")
+						.password("1234567890")
+						.name("testUser")
+						.phoneNumber("01012345678")
+						.createdAt(LocalDateTime.now())
+						.modifiedAt(LocalDateTime.now())
+						.build()
 					)
 				);
 			UserSignInRequest userSignInRequest = new UserSignInRequest(
@@ -221,14 +223,15 @@ class UserControllerTest {
 				.thenReturn("not_equals_text");
 			Mockito.when(userRepository.findByEmail(Mockito.anyString()))
 				.thenReturn(
-					Optional.of(new UserPersist(
-							"test@email.com",
-							"1234567890",
-							"testUser",
-							"01012345678",
-							LocalDateTime.now(),
-							LocalDateTime.now()
-						)
+					Optional.of(UserPersist.builder()
+						.id(1L)
+						.email("test@email.com")
+						.password("1234567890")
+						.name("testUser")
+						.phoneNumber("01012345678")
+						.createdAt(LocalDateTime.now())
+						.modifiedAt(LocalDateTime.now())
+						.build()
 					)
 				);
 			UserSignInRequest userSignInRequest = new UserSignInRequest(


### PR DESCRIPTION
## 관련된 이슈 번호
- issue : #42 

## 변경사항 (할 일)
- [X] User 엔티티에서 id (pk)를 이용할 일이 있음에 따라 User 엔티티 내 `id` 필드를 추가하였습니다
- [X] `id` 필드를 추가하였기 때문에 로그인 완료 시 세션에 이메일 대신 `id` 를 저장하도록 변경하였습니다
- [X] `id` 필드가 `UserPersist` 및 `User` 에 추가되어 관련된 테스트 코드를 수정하였습니다
## 추가 점검사항
- [X] test case
