### PR TITLE
[Fix] 로컬 환경에서 application-secret의 PASSWORD_SALT 값이 없어서 실행되지 않는 버그 수정

### DIFF
--- a/app/src/main/resources/application-secret.yml
+++ b/app/src/main/resources/application-secret.yml
@@ -1,0 +1,1 @@
+PASSWORD_SALT: testsalt1234


### PR DESCRIPTION
## 관련된 이슈 번호
- issue : #66 

## 변경사항 (할 일)
- [X] `application-secret.yml` 내 `PASSWORD_SALT` 기본값을 추가하여 로컬에서 실행하는데 문제가 없도록 수정하였습니다
    - [X] 실제 운영 환경에서는 PASSWORD_SALT 값을 별도로 지정할 에정 입니다 

## 추가 점검사항
