### PR TITLE
[Feature] 공연 좌석 가격 조회 API 설계

### DIFF
--- a/app/src/main/java/com/picketing/www/business/domain/show/Show.java
+++ b/app/src/main/java/com/picketing/www/business/domain/show/Show.java
@@ -20,7 +20,6 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -29,7 +28,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "SHOW")
 @Getter(AccessLevel.PROTECTED)
-@Builder(access = AccessLevel.PROTECTED)
 public class Show extends BaseEntity {
 
 	@Id

--- a/app/src/main/java/com/picketing/www/business/domain/show/Show.java
+++ b/app/src/main/java/com/picketing/www/business/domain/show/Show.java
@@ -1,7 +1,10 @@
 package com.picketing.www.business.domain.show;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
+import com.picketing.www.business.domain.show.seatgrade.Seat;
 import com.picketing.www.business.type.AgeGroup;
 import com.picketing.www.business.type.Genre;
 import com.picketing.www.business.type.SubGenre;
@@ -13,6 +16,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -50,4 +54,7 @@ public class Show extends BaseEntity {
 	private String details;
 	private boolean isBookable;
 	private Long ownerId;
+
+	@OneToMany(mappedBy = "show")
+	private List<Seat> seatList = new ArrayList<>();
 }

--- a/app/src/main/java/com/picketing/www/business/domain/show/seatgrade/Seat.java
+++ b/app/src/main/java/com/picketing/www/business/domain/show/seatgrade/Seat.java
@@ -1,8 +1,10 @@
 package com.picketing.www.business.domain.show.seatgrade;
 
+import com.picketing.www.business.domain.show.Show;
 import com.picketing.www.persistence.table.BaseEntity;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -18,9 +20,9 @@ public class Seat extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@ManyToOne
-	@JoinColumn(name = "SEAT_GRADE_ID")
-	private SeatGrade seatGrade;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "SHOW_ID")
+	private Show show;
 
 	// TODO 23.09.13: Time schedule id mapping. @ManyToOne
 	private Long timeScheduleId;

--- a/app/src/main/java/com/picketing/www/business/domain/show/seatgrade/Seat.java
+++ b/app/src/main/java/com/picketing/www/business/domain/show/seatgrade/Seat.java
@@ -1,0 +1,27 @@
+package com.picketing.www.business.domain.show.seatgrade;
+
+import com.picketing.www.persistence.table.BaseEntity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Seat extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "SEAT_GRADE_ID")
+	private SeatGrade seatGrade;
+
+	// TODO 23.09.13: Time schedule id mapping. @ManyToOne
+	private Long timeScheduleId;
+}

--- a/app/src/main/java/com/picketing/www/business/domain/show/seatgrade/SeatGrade.java
+++ b/app/src/main/java/com/picketing/www/business/domain/show/seatgrade/SeatGrade.java
@@ -19,7 +19,6 @@ public class SeatGrade {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 	private String name;
-  
 	private BigDecimal price;
 
 	@ManyToOne

--- a/app/src/main/java/com/picketing/www/business/domain/show/seatgrade/SeatGrade.java
+++ b/app/src/main/java/com/picketing/www/business/domain/show/seatgrade/SeatGrade.java
@@ -1,0 +1,26 @@
+package com.picketing.www.business.domain.show.seatgrade;
+
+import com.picketing.www.business.domain.show.Show;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SeatGrade {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	private String name;
+
+	@ManyToOne
+	@JoinColumn(name = "SHOW_ID")
+	private Show show;
+}

--- a/app/src/main/java/com/picketing/www/business/domain/show/seatgrade/SeatGrade.java
+++ b/app/src/main/java/com/picketing/www/business/domain/show/seatgrade/SeatGrade.java
@@ -1,6 +1,6 @@
 package com.picketing.www.business.domain.show.seatgrade;
 
-import com.picketing.www.business.domain.show.Show;
+import java.math.BigDecimal;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -19,8 +19,9 @@ public class SeatGrade {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 	private String name;
+	private BigDecimal price;
 
 	@ManyToOne
-	@JoinColumn(name = "SHOW_ID")
-	private Show show;
+	@JoinColumn(name = "SEAT_ID")
+	private Seat seat;
 }

--- a/app/src/main/java/com/picketing/www/business/service/show/ShowService.java
+++ b/app/src/main/java/com/picketing/www/business/service/show/ShowService.java
@@ -1,5 +1,6 @@
 package com.picketing.www.business.service.show;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
@@ -20,5 +21,9 @@ public class ShowService {
 
 	public List<Show> getShowList(Genre genre, SubGenre subGenre, Pageable pageable) {
 		return showRepository.findShowsByGenreAndSubGenre(genre, subGenre, pageable);
+	}
+
+	public List<?> getShowSeatBasicPriceList(Long showId) {
+		return new ArrayList<>();
 	}
 }

--- a/app/src/main/java/com/picketing/www/business/service/show/ShowService.java
+++ b/app/src/main/java/com/picketing/www/business/service/show/ShowService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import com.picketing.www.business.domain.show.Show;
+import com.picketing.www.business.domain.show.seatgrade.SeatGrade;
 import com.picketing.www.business.type.Genre;
 import com.picketing.www.business.type.SubGenre;
 import com.picketing.www.persistence.repository.show.ShowRepository;
@@ -23,7 +24,7 @@ public class ShowService {
 		return showRepository.findShowsByGenreAndSubGenre(genre, subGenre, pageable);
 	}
 
-	public List<?> getShowSeatBasicPriceList(Long showId) {
+	public List<SeatGrade> getShowSeatBasicPriceList(Long showId) {
 		return new ArrayList<>();
 	}
 }

--- a/app/src/main/java/com/picketing/www/presentation/controller/show/ShowController.java
+++ b/app/src/main/java/com/picketing/www/presentation/controller/show/ShowController.java
@@ -1,6 +1,5 @@
 package com.picketing.www.presentation.controller.show;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -47,7 +46,7 @@ public class ShowController {
 	}
 
 	@GetMapping("/{showId}/basic-price")
-	public List<ShowSeatPriceResponse> getShowSeatBasicPriceList(
+	public ShowSeatPriceResponse getShowSeatBasicPriceList(
 		@PathVariable Long showId
 	) {
 		// List<ShowSeatPriceResponse> seatBasicPriceList = showService.getShowSeatBasicPriceList(showId)
@@ -55,7 +54,7 @@ public class ShowController {
 		// 	.map(new ShowSeatPriceResponse(showId, "VIP", new BigDecimal(165000)))
 		// 	.collect(Collectors.toList());
 
-		return new ArrayList<>();
+		return ShowSeatPriceResponse.builder().build();
 	}
 
 }

--- a/app/src/main/java/com/picketing/www/presentation/controller/show/ShowController.java
+++ b/app/src/main/java/com/picketing/www/presentation/controller/show/ShowController.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +20,7 @@ import com.picketing.www.business.service.show.ShowService;
 import com.picketing.www.business.type.Genre;
 import com.picketing.www.business.type.SubGenre;
 import com.picketing.www.presentation.dto.response.show.ShowMainResponse;
+import com.picketing.www.presentation.dto.response.show.ShowSeatPriceResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -42,4 +44,17 @@ public class ShowController {
 			.collect(Collectors.toList());
 		return new PageImpl<>(response, pageable, response.size());
 	}
+
+	@GetMapping("/{showId}/basic-price")
+	public List<ShowSeatPriceResponse> getShowSeatBasicPriceList(
+		@PathVariable Long showId
+	) {
+		List<ShowSeatPriceResponse> seatBasicPriceList = showService.getShowSeatBasicPriceList(showId)
+			.stream()
+			.map()
+			.collect(Collectors.toList());
+
+		return seatBasicPriceList;
+	}
+
 }

--- a/app/src/main/java/com/picketing/www/presentation/controller/show/ShowController.java
+++ b/app/src/main/java/com/picketing/www/presentation/controller/show/ShowController.java
@@ -1,5 +1,6 @@
 package com.picketing.www.presentation.controller.show;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -49,12 +50,12 @@ public class ShowController {
 	public List<ShowSeatPriceResponse> getShowSeatBasicPriceList(
 		@PathVariable Long showId
 	) {
-		List<ShowSeatPriceResponse> seatBasicPriceList = showService.getShowSeatBasicPriceList(showId)
-			.stream()
-			.map()
-			.collect(Collectors.toList());
+		// List<ShowSeatPriceResponse> seatBasicPriceList = showService.getShowSeatBasicPriceList(showId)
+		// 	.stream()
+		// 	.map(new ShowSeatPriceResponse(showId, "VIP", new BigDecimal(165000)))
+		// 	.collect(Collectors.toList());
 
-		return seatBasicPriceList;
+		return new ArrayList<>();
 	}
 
 }

--- a/app/src/main/java/com/picketing/www/presentation/controller/show/ShowController.java
+++ b/app/src/main/java/com/picketing/www/presentation/controller/show/ShowController.java
@@ -45,8 +45,8 @@ public class ShowController {
 		return new PageImpl<>(response, pageable, response.size());
 	}
 
-	@GetMapping("/{showId}/basic-price")
-	public ShowSeatPriceResponse getShowSeatBasicPriceList(
+	@GetMapping("/{showId}/seatGrade")
+	public ShowSeatPriceResponse getShowSeatGradeList(
 		@PathVariable Long showId
 	) {
 		return ShowSeatPriceResponse.builder().build();

--- a/app/src/main/java/com/picketing/www/presentation/controller/show/ShowController.java
+++ b/app/src/main/java/com/picketing/www/presentation/controller/show/ShowController.java
@@ -49,11 +49,6 @@ public class ShowController {
 	public ShowSeatPriceResponse getShowSeatBasicPriceList(
 		@PathVariable Long showId
 	) {
-		// List<ShowSeatPriceResponse> seatBasicPriceList = showService.getShowSeatBasicPriceList(showId)
-		// 	.stream()
-		// 	.map(new ShowSeatPriceResponse(showId, "VIP", new BigDecimal(165000)))
-		// 	.collect(Collectors.toList());
-
 		return ShowSeatPriceResponse.builder().build();
 	}
 

--- a/app/src/main/java/com/picketing/www/presentation/dto/response/show/ShowSeatPriceResponse.java
+++ b/app/src/main/java/com/picketing/www/presentation/dto/response/show/ShowSeatPriceResponse.java
@@ -1,13 +1,19 @@
 package com.picketing.www.presentation.dto.response.show;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import lombok.Builder;
 
 @Builder
 public record ShowSeatPriceResponse(
-	Long showId,
-	String seatGradeName,
-	BigDecimal price
+	List<ShowSeatBasicPriceResponseDto> basicPriceList
 ) {
+
+	public record ShowSeatBasicPriceResponseDto(
+		Long showId,
+		String seatGradeName,
+		BigDecimal price
+	) {
+	}
 }

--- a/app/src/main/java/com/picketing/www/presentation/dto/response/show/ShowSeatPriceResponse.java
+++ b/app/src/main/java/com/picketing/www/presentation/dto/response/show/ShowSeatPriceResponse.java
@@ -3,15 +3,22 @@ package com.picketing.www.presentation.dto.response.show;
 import java.math.BigDecimal;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.Builder;
 
 @Builder
 public record ShowSeatPriceResponse(
+
+	@JsonProperty("basic_price_list")
 	List<ShowSeatBasicPriceResponseDto> basicPriceList
 ) {
 
 	public record ShowSeatBasicPriceResponseDto(
+		@JsonProperty("show_id")
 		Long showId,
+
+		@JsonProperty("seat_grade_name")
 		String seatGradeName,
 		BigDecimal price
 	) {

--- a/app/src/main/java/com/picketing/www/presentation/dto/response/show/ShowSeatPriceResponse.java
+++ b/app/src/main/java/com/picketing/www/presentation/dto/response/show/ShowSeatPriceResponse.java
@@ -1,0 +1,13 @@
+package com.picketing.www.presentation.dto.response.show;
+
+import java.math.BigDecimal;
+
+import lombok.Builder;
+
+@Builder
+public record ShowSeatPriceResponse(
+	Long showId,
+	String seatGradeName,
+	BigDecimal price
+) {
+}

--- a/app/src/main/java/com/picketing/www/presentation/dto/response/show/ShowSeatPriceResponse.java
+++ b/app/src/main/java/com/picketing/www/presentation/dto/response/show/ShowSeatPriceResponse.java
@@ -3,22 +3,15 @@ package com.picketing.www.presentation.dto.response.show;
 import java.math.BigDecimal;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import lombok.Builder;
 
 @Builder
 public record ShowSeatPriceResponse(
-
-	@JsonProperty("basic_price_list")
 	List<ShowSeatBasicPriceResponseDto> basicPriceList
 ) {
 
 	public record ShowSeatBasicPriceResponseDto(
-		@JsonProperty("show_id")
 		Long showId,
-
-		@JsonProperty("seat_grade_name")
 		String seatGradeName,
 		BigDecimal price
 	) {


### PR DESCRIPTION
## 관련된 이슈 번호
- issue : #61 

## 변경사항 (할 일)
- [X] #64 에서 설계 완료된 좌석 도메인을 바탕으로, 특정 공연의 좌석 가격 리스트를 조회하는 API 설계
- [X] 비어있는 컨트롤러를 설계합니다
    - 관련 메소드 : `ShowController` 내 `getShowSeatBasicPriceList`
    - API URL : `/api/show/{showId}/basic-price`
    - Request 형식 : PathVariable 로 `showId` 필요
    - Response 형식 
        ```javascript
        "basic_price_list" : [
                 {
                  "show_id": 1L,
                  "seat_grade_name": "VIP",
                  "price": 165000
                  },
                 {
                  "show_id": 1L,
                  "seat_grade_name": "SR",
                  "price": 154000
                  },
                 {
                  "show_id": 1L,
                  "seat_grade_name": "R",
                  "price": 143000
                  },
                 {
                  "show_id": 1L,
                  "seat_grade_name": "S",
                  "price": 121000
                  },
        ]
        ```

## 추가 점검사항
- [x] #64 에서 도메인 설계 변경 사항이 있을 경우, 수정 사항을 반영해야합니다
- [x] #64 에 의존성을 가지고 있어서, #64 가 머지된 이후 머지할 수 있습니다
