### PR TITLE
[Feature] 공연 예매 & 좌석 예매 도메인 설계

### DIFF
--- a/app/src/main/java/com/picketing/www/business/domain/reservation/Reservation.java
+++ b/app/src/main/java/com/picketing/www/business/domain/reservation/Reservation.java
@@ -1,0 +1,39 @@
+package com.picketing.www.business.domain.reservation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.picketing.www.business.domain.show.Show;
+import com.picketing.www.persistence.table.BaseEntity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "RESERVATION")
+public class Reservation extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "show_id")
+	private Show show;
+
+	// TODO UserPersist -> User Entity로 JPA 적용하도록 변경
+	// @ManyToOne(fetch = FetchType.LAZY)
+	// @JoinColumn(name = "user_id")
+	// private User user;
+
+	@OneToMany(mappedBy = "reservation")
+	private List<ReservationSeat> reservationSeatList = new ArrayList<>();
+
+}

--- a/app/src/main/java/com/picketing/www/business/domain/reservation/Reservation.java
+++ b/app/src/main/java/com/picketing/www/business/domain/reservation/Reservation.java
@@ -34,6 +34,6 @@ public class Reservation extends BaseEntity {
 	// private User user;
 
 	@OneToMany(mappedBy = "reservation")
-	private List<ReservationSeat> reservationSeatList = new ArrayList<>();
+	private List<ReservedSeat> reservedSeatList = new ArrayList<>();
 
 }

--- a/app/src/main/java/com/picketing/www/business/domain/reservation/ReservationSeat.java
+++ b/app/src/main/java/com/picketing/www/business/domain/reservation/ReservationSeat.java
@@ -1,0 +1,28 @@
+package com.picketing.www.business.domain.reservation;
+
+import com.picketing.www.business.domain.show.seatgrade.Seat;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "RESERVATION_SEAT")
+public class ReservationSeat {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "reservation_id")
+	private Reservation reservation;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "seat_id")
+	private Seat seat;
+}

--- a/app/src/main/java/com/picketing/www/business/domain/reservation/ReservedSeat.java
+++ b/app/src/main/java/com/picketing/www/business/domain/reservation/ReservedSeat.java
@@ -12,7 +12,7 @@ import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "RESERVATION_SEAT")
-public class ReservationSeat {
+public class ReservedSeat {
 
 	@Id
 	@GeneratedValue


### PR DESCRIPTION
## 관련된 이슈 번호
- issue : #77 

## 변경사항 (할 일)
- [X] `Show` 와 `User` 간 매핑 테이블의 개념 (공연 예매) 으로 `Reservation` 도메인 설계
- [X] `Seat` 과 `Reservation` 간 매핑 테이블의 개념(공연에 대한 좌석 예매)으로 `ReservedSeat` 도메인 설계
    - [X] 하나의 공연 예매 건에 여러 개의 좌석을 선택할 수 있어서 `ReservedSeat` 을 별도의 엔티티로 분리하였지만 잘 설계된 것인지 의문이듭니다.. 더 쉽게 할 수 있는 방법은 없는지...?.... 의문이 듭니다

## 추가 점검사항
- [ ] document (db migration을 위한 mysql-files)
