### PR TITLE
[Feature] 잔여 좌석 조회 API 구현

### DIFF
--- a/app/src/main/java/com/picketing/www/application/interceptor/LoginCheckInterceptor.java
+++ b/app/src/main/java/com/picketing/www/application/interceptor/LoginCheckInterceptor.java
@@ -17,8 +17,6 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
 		Exception {
 		HttpSession session = request.getSession();
 		Long userId = (Long)session.getAttribute("login_user");
-		System.out.println("LoginCheckInterceptor.preHandle");
-		System.out.println("userId = " + userId);
 
 		if (userId == null || userId == 0L) {
 			throw new CustomException(ErrorCode.UNAUTHORIZED);

--- a/app/src/main/java/com/picketing/www/application/interceptor/LoginCheckInterceptor.java
+++ b/app/src/main/java/com/picketing/www/application/interceptor/LoginCheckInterceptor.java
@@ -17,6 +17,8 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
 		Exception {
 		HttpSession session = request.getSession();
 		Long userId = (Long)session.getAttribute("login_user");
+		System.out.println("LoginCheckInterceptor.preHandle");
+		System.out.println("userId = " + userId);
 
 		if (userId == null || userId == 0L) {
 			throw new CustomException(ErrorCode.UNAUTHORIZED);

--- a/app/src/main/java/com/picketing/www/business/domain/reservation/ScheduledShowSeat.java
+++ b/app/src/main/java/com/picketing/www/business/domain/reservation/ScheduledShowSeat.java
@@ -42,4 +42,10 @@ public class ScheduledShowSeat extends BaseEntity {
 
 	@Enumerated(EnumType.STRING)
 	private SeatGrade seatGrade;
+
+	public ScheduledShowSeat(Show show, LocalDateTime showDateTime, SeatGrade seatGrade) {
+		this.show = show;
+		this.showDateTime = showDateTime;
+		this.seatGrade = seatGrade;
+	}
 }

--- a/app/src/main/java/com/picketing/www/business/domain/reservation/ScheduledShowSeatFactory.java
+++ b/app/src/main/java/com/picketing/www/business/domain/reservation/ScheduledShowSeatFactory.java
@@ -1,0 +1,17 @@
+package com.picketing.www.business.domain.reservation;
+
+import org.springframework.stereotype.Component;
+
+import com.picketing.www.presentation.dto.response.show.seat.ScheduledShowSeatGradeResponse;
+
+@Component
+public class ScheduledShowSeatFactory {
+
+	public ScheduledShowSeatGradeResponse convertShowSeat(ScheduledShowSeat showSeat) {
+		return ScheduledShowSeatGradeResponse.builder()
+			.show(showSeat.getShow())
+			.seatGrade(showSeat.getSeatGrade())
+			.showTime(showSeat.getShowDateTime())
+			.build();
+	}
+}

--- a/app/src/main/java/com/picketing/www/business/domain/show/seat/SeatGradeFactory.java
+++ b/app/src/main/java/com/picketing/www/business/domain/show/seat/SeatGradeFactory.java
@@ -42,6 +42,23 @@ package com.picketing.www.business.domain.show.seat;
 
 import org.springframework.stereotype.Component;
 
+import com.picketing.www.presentation.dto.response.show.seat.ScheduledShowSeatGradeResponse;
+import com.picketing.www.presentation.dto.response.show.seat.SeatGradeResponse;
+
 @Component
 public class SeatGradeFactory {
+
+	public SeatGradeResponse convertSeatGradeToResponse(SeatGrade seatGrade) {
+		return SeatGradeResponse.builder()
+			.seatGrade(seatGrade.getName())
+			.totalCount(seatGrade.getCount())
+			.build();
+	}
+
+	public SeatGradeResponse convertSeatGradeFromShowSeat(ScheduledShowSeatGradeResponse scheduledShowSeat) {
+		return SeatGradeResponse.builder()
+			.seatGrade(scheduledShowSeat.seatGrade().getName())
+			.totalCount(scheduledShowSeat.seatGrade().getCount())
+			.build();
+	}
 }

--- a/app/src/main/java/com/picketing/www/business/domain/show/seat/SeatGradeFactory.java
+++ b/app/src/main/java/com/picketing/www/business/domain/show/seat/SeatGradeFactory.java
@@ -40,8 +40,13 @@
 
 package com.picketing.www.business.domain.show.seat;
 
+import static com.picketing.www.presentation.dto.response.show.seat.RemainingSeatsResponse.*;
+
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
+import com.picketing.www.presentation.dto.response.show.seat.RemainingSeatsResponse;
 import com.picketing.www.presentation.dto.response.show.seat.ScheduledShowSeatGradeResponse;
 import com.picketing.www.presentation.dto.response.show.seat.SeatGradeResponse;
 
@@ -59,6 +64,12 @@ public class SeatGradeFactory {
 		return SeatGradeResponse.builder()
 			.seatGrade(scheduledShowSeat.seatGrade().getName())
 			.totalCount(scheduledShowSeat.seatGrade().getCount())
+			.build();
+	}
+
+	public RemainingSeatsResponse convertRemainingSeats(List<RemainingSeatDetail> seatDetail) {
+		return builder()
+			.remainSeats(seatDetail)
 			.build();
 	}
 }

--- a/app/src/main/java/com/picketing/www/business/service/reservation/ReservationService.java
+++ b/app/src/main/java/com/picketing/www/business/service/reservation/ReservationService.java
@@ -16,7 +16,6 @@ import com.picketing.www.business.domain.reservation.ReservationFactory;
 import com.picketing.www.business.domain.reservation.ScheduledShowSeat;
 import com.picketing.www.business.domain.show.Show;
 import com.picketing.www.business.domain.show.seat.SeatGrade;
-import com.picketing.www.business.service.show.ShowService;
 import com.picketing.www.business.service.user.UserService;
 import com.picketing.www.persistence.repository.reservation.ReservationRepository;
 import com.picketing.www.presentation.dto.request.reservation.ReservationRequest;
@@ -28,8 +27,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ReservationService {
 
-	private final ShowService showService;
-
 	private final ScheduledShowSeatService scheduledShowSeatService;
 
 	private final UserService userService;
@@ -39,11 +36,9 @@ public class ReservationService {
 	private final ReservationFactory reservationFactory;
 
 	@Transactional
-	public List<Reservation> makeReservations(ReservationRequest request) {
+	public List<Reservation> makeReservations(Show show, ReservationRequest request) {
 		// TODO 이후 세션에서 userId 가지고 올 수 있도록 수정 필요
 		User user = userService.get(request.userId());
-
-		Show show = showService.getShowById(request.showId());
 
 		String showTime = request.showTime();
 

--- a/app/src/main/java/com/picketing/www/business/service/reservation/ReservationService.java
+++ b/app/src/main/java/com/picketing/www/business/service/reservation/ReservationService.java
@@ -13,6 +13,7 @@ import com.picketing.www.application.exception.ErrorCode;
 import com.picketing.www.business.domain.User;
 import com.picketing.www.business.domain.reservation.Reservation;
 import com.picketing.www.business.domain.reservation.ReservationFactory;
+import com.picketing.www.business.domain.reservation.ScheduledShowSeat;
 import com.picketing.www.business.domain.show.Show;
 import com.picketing.www.business.domain.show.seat.SeatGrade;
 import com.picketing.www.business.service.show.ShowService;
@@ -63,7 +64,7 @@ public class ReservationService {
 		return seatRequestList.stream()
 			.allMatch(seatRequest -> {
 				SeatGrade currentSeatGrade = seatRequest.seatGrade();
-				long reservedCount = reservationRepository.countReservationsByShowSeat(
+				long reservedCount = countReservationsByShowSeat(
 					scheduledShowSeatService.getScheduledShowSeat(show, showTime,
 						currentSeatGrade));
 
@@ -79,4 +80,12 @@ public class ReservationService {
 			))
 			.collect(Collectors.toList());
 	}
+
+	public Long countReservationsByShowSeat(ScheduledShowSeat scheduledShowSeat) {
+		return reservationRepository.countReservationsByShowSeat(scheduledShowSeat);
+	}
+
+	// public List<Reservation> getReservationsByShowSeat(ScheduledShowSeat scheduledShowSeat) {
+	// 	return reservationRepository.findAllByShowSeat(scheduledShowSeat);
+	// }
 }

--- a/app/src/main/java/com/picketing/www/business/service/reservation/ReservationService.java
+++ b/app/src/main/java/com/picketing/www/business/service/reservation/ReservationService.java
@@ -85,7 +85,7 @@ public class ReservationService {
 		return reservationRepository.countReservationsByShowSeat(scheduledShowSeat);
 	}
 
-	// public List<Reservation> getReservationsByShowSeat(ScheduledShowSeat scheduledShowSeat) {
-	// 	return reservationRepository.findAllByShowSeat(scheduledShowSeat);
-	// }
+	public List<Reservation> getReservationsByShowSeat(ScheduledShowSeat scheduledShowSeat) {
+		return reservationRepository.findAllByShowSeat(scheduledShowSeat);
+	}
 }

--- a/app/src/main/java/com/picketing/www/business/service/reservation/ReservationService.java
+++ b/app/src/main/java/com/picketing/www/business/service/reservation/ReservationService.java
@@ -2,6 +2,7 @@ package com.picketing.www.business.service.reservation;
 
 import static com.picketing.www.presentation.dto.request.reservation.ReservationRequest.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -40,7 +41,7 @@ public class ReservationService {
 		// TODO 이후 세션에서 userId 가지고 올 수 있도록 수정 필요
 		User user = userService.get(request.userId());
 
-		String showTime = request.showTime();
+		LocalDateTime showTime = request.showTime();
 
 		// 각 좌석이 구매 가능한지 확인
 		if (!isBookable(show, showTime, request.seatGradeList())) {
@@ -55,7 +56,7 @@ public class ReservationService {
 		return reservationRepository.saveAll(reservations);
 	}
 
-	private boolean isBookable(Show show, String showTime, List<ReservationSeatRequest> seatRequestList) {
+	private boolean isBookable(Show show, LocalDateTime showTime, List<ReservationSeatRequest> seatRequestList) {
 		return seatRequestList.stream()
 			.allMatch(seatRequest -> {
 				SeatGrade currentSeatGrade = seatRequest.seatGrade();
@@ -67,7 +68,7 @@ public class ReservationService {
 			});
 	}
 
-	private List<Reservation> makeReservationPerCount(User user, Show show, String showTime,
+	private List<Reservation> makeReservationPerCount(User user, Show show, LocalDateTime showTime,
 		ReservationSeatRequest request) {
 		return IntStream.range(0, request.count())
 			.mapToObj(i -> reservationFactory.convertSeatToReservation(user,

--- a/app/src/main/java/com/picketing/www/business/service/reservation/ScheduledShowSeatService.java
+++ b/app/src/main/java/com/picketing/www/business/service/reservation/ScheduledShowSeatService.java
@@ -1,7 +1,6 @@
 package com.picketing.www.business.service.reservation;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -21,15 +20,13 @@ public class ScheduledShowSeatService {
 
 	private final ScheduledShowSeatRepository scheduledShowSeatRepository;
 
-	public ScheduledShowSeat getScheduledShowSeat(Show show, String showTime, SeatGrade seatGrade) {
-		return scheduledShowSeatRepository.findScheduledShowSeatByShowAndShowDateTimeAndSeatGrade(show,
-				LocalDateTime.parse(showTime, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")),
+	public ScheduledShowSeat getScheduledShowSeat(Show show, LocalDateTime showTime, SeatGrade seatGrade) {
+		return scheduledShowSeatRepository.findScheduledShowSeatByShowAndShowDateTimeAndSeatGrade(show, showTime,
 				seatGrade)
 			.orElseThrow(() -> new CustomException(ErrorCode.SHOW_NOT_FOUND));
 	}
 
-	public List<ScheduledShowSeat> getScheduledShowSeatList(Show show, String showTime) {
-		return scheduledShowSeatRepository.findAllByShowAndShowDateTime(show,
-			LocalDateTime.parse(showTime, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
+	public List<ScheduledShowSeat> getScheduledShowSeatList(Show show, LocalDateTime showTime) {
+		return scheduledShowSeatRepository.findAllByShowAndShowDateTime(show, showTime);
 	}
 }

--- a/app/src/main/java/com/picketing/www/business/service/reservation/ScheduledShowSeatService.java
+++ b/app/src/main/java/com/picketing/www/business/service/reservation/ScheduledShowSeatService.java
@@ -2,6 +2,7 @@ package com.picketing.www.business.service.reservation;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 import org.springframework.stereotype.Service;
 
@@ -25,5 +26,10 @@ public class ScheduledShowSeatService {
 				LocalDateTime.parse(showTime, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")),
 				seatGrade)
 			.orElseThrow(() -> new CustomException(ErrorCode.SHOW_NOT_FOUND));
+	}
+
+	public List<ScheduledShowSeat> getScheduledShowSeatList(Show show, String showTime) {
+		return scheduledShowSeatRepository.findAllByShowAndShowDateTime(show,
+			LocalDateTime.parse(showTime, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")));
 	}
 }

--- a/app/src/main/java/com/picketing/www/business/service/show/ShowService.java
+++ b/app/src/main/java/com/picketing/www/business/service/show/ShowService.java
@@ -5,14 +5,21 @@ import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.picketing.www.application.exception.CustomException;
 import com.picketing.www.application.exception.ErrorCode;
+import com.picketing.www.business.domain.reservation.Reservation;
+import com.picketing.www.business.domain.reservation.ScheduledShowSeat;
+import com.picketing.www.business.domain.reservation.ScheduledShowSeatFactory;
 import com.picketing.www.business.domain.show.Show;
 import com.picketing.www.business.domain.show.seat.SeatGrade;
+import com.picketing.www.business.service.reservation.ReservationService;
+import com.picketing.www.business.service.reservation.ScheduledShowSeatService;
 import com.picketing.www.business.type.Genre;
 import com.picketing.www.business.type.SubGenre;
 import com.picketing.www.persistence.repository.show.ShowRepository;
+import com.picketing.www.presentation.dto.response.show.seat.RemainingSeatsResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,6 +28,10 @@ import lombok.RequiredArgsConstructor;
 public class ShowService {
 
 	private final ShowRepository showRepository;
+	private final ReservationService reservationService;
+	private final ScheduledShowSeatService scheduledShowSeatService;
+
+	private final ScheduledShowSeatFactory scheduledShowSeatFactory;
 
 	// TODO 카테고리에 따른 공연 목록 조회 로직 구현
 	public List<Show> getShowList(Genre genre, SubGenre subGenre, Pageable pageable) {
@@ -40,4 +51,19 @@ public class ShowService {
 		return showRepository.findById(showId)
 			.orElseThrow(() -> new CustomException(ErrorCode.SHOW_NOT_FOUND));
 	}
+
+	@Transactional(readOnly = true)
+	public List<RemainingSeatsResponse.RemainingSeatDetail> getRemainingSeats(Long showId, String showTime) {
+		// 공연의 등급별 좌석 리스트
+		List<ScheduledShowSeat> scheduledShowSeatList = scheduledShowSeatService.getScheduledShowSeatList(
+			getShowById(showId), showTime);
+
+		scheduledShowSeatService.getScheduledShowSeatList()
+
+		scheduledShowSeatList.forEach(showSeat -> {
+			// 예약된 좌석 리스트
+			List<Reservation> reservedSeatList = reservationService.getReservationsByShowSeat(showSeat);
+		});
+	}
+
 }

--- a/app/src/main/java/com/picketing/www/business/service/show/ShowService.java
+++ b/app/src/main/java/com/picketing/www/business/service/show/ShowService.java
@@ -30,6 +30,7 @@ public class ShowService {
 
 	private final ShowRepository showRepository;
 	private final ReservationService reservationService;
+
 	private final ScheduledShowSeatService scheduledShowSeatService;
 
 	private final ScheduledShowSeatFactory scheduledShowSeatFactory;
@@ -68,8 +69,7 @@ public class ShowService {
 		scheduledShowSeatList.forEach(showSeat -> {
 			// 예약된 좌석 리스트
 			// List<Reservation> reservedSeatList = reservationService.getReservationsByShowSeat(showSeat);
-			ScheduledShowSeatGradeResponse response = scheduledShowSeatFactory.convertShowSeat(
-				showSeat);
+			ScheduledShowSeatGradeResponse response = scheduledShowSeatFactory.convertShowSeat(showSeat);
 			Long reserved = reservationService.countReservationsByShowSeat(showSeat);
 			int remainSeatCnt = Integer.parseInt(
 				String.valueOf(response.seatGrade().getCount() - reserved));

--- a/app/src/main/java/com/picketing/www/business/service/show/ShowService.java
+++ b/app/src/main/java/com/picketing/www/business/service/show/ShowService.java
@@ -2,6 +2,7 @@ package com.picketing.www.business.service.show;
 
 import static com.picketing.www.presentation.dto.response.show.seat.RemainingSeatsResponse.*;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 public class ShowService {
 
 	private final ShowRepository showRepository;
+
 	private final ReservationService reservationService;
 
 	private final ScheduledShowSeatService scheduledShowSeatService;
@@ -55,20 +57,15 @@ public class ShowService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<RemainingSeatDetail> getRemainingSeats(Long showId, String showTime) {
+	public List<RemainingSeatDetail> getRemainingSeats(Long showId, LocalDateTime showTime) {
 		List<RemainingSeatDetail> cntList = new ArrayList<>();
 
 		// 공연의 등급별 좌석 리스트
 		List<ScheduledShowSeat> scheduledShowSeatList = scheduledShowSeatService.getScheduledShowSeatList(
 			getShowById(showId), showTime);
 
-		List<ScheduledShowSeatGradeResponse> result = scheduledShowSeatList.stream()
-			.map(scheduledShowSeatFactory::convertShowSeat)
-			.toList();
-
 		scheduledShowSeatList.forEach(showSeat -> {
 			// 예약된 좌석 리스트
-			// List<Reservation> reservedSeatList = reservationService.getReservationsByShowSeat(showSeat);
 			ScheduledShowSeatGradeResponse response = scheduledShowSeatFactory.convertShowSeat(showSeat);
 			Long reserved = reservationService.countReservationsByShowSeat(showSeat);
 			int remainSeatCnt = Integer.parseInt(

--- a/app/src/main/java/com/picketing/www/persistence/repository/reservation/ReservationRepository.java
+++ b/app/src/main/java/com/picketing/www/persistence/repository/reservation/ReservationRepository.java
@@ -1,5 +1,7 @@
 package com.picketing.www.persistence.repository.reservation;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,5 +11,7 @@ import com.picketing.www.business.domain.reservation.ScheduledShowSeat;
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
-	long countReservationsByShowSeat(ScheduledShowSeat scheduledShowSeat);
+	Long countReservationsByShowSeat(ScheduledShowSeat scheduledShowSeat);
+
+	List<Reservation> findAllByShowSeat(ScheduledShowSeat scheduledShowSeat);
 }

--- a/app/src/main/java/com/picketing/www/persistence/repository/reservation/ScheduledShowSeatRepository.java
+++ b/app/src/main/java/com/picketing/www/persistence/repository/reservation/ScheduledShowSeatRepository.java
@@ -1,6 +1,7 @@
 package com.picketing.www.persistence.repository.reservation;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,4 +16,6 @@ public interface ScheduledShowSeatRepository extends JpaRepository<ScheduledShow
 	Optional<ScheduledShowSeat> findScheduledShowSeatByShowAndShowDateTimeAndSeatGrade(Show show,
 		LocalDateTime startDateTime,
 		SeatGrade seatGrade);
+
+	List<ScheduledShowSeat> findAllByShowAndShowDateTime(Show show, LocalDateTime showDateTime);
 }

--- a/app/src/main/java/com/picketing/www/presentation/controller/reservation/ReservationController.java
+++ b/app/src/main/java/com/picketing/www/presentation/controller/reservation/ReservationController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.picketing.www.business.domain.reservation.ReservationFactory;
 import com.picketing.www.business.service.reservation.ReservationService;
+import com.picketing.www.business.service.show.ShowService;
 import com.picketing.www.presentation.dto.request.reservation.ReservationRequest;
 import com.picketing.www.presentation.dto.response.reservation.MakeReservationResponse;
 
@@ -20,10 +21,12 @@ public class ReservationController {
 	private final ReservationFactory reservationFactory;
 	private final ReservationService reservationService;
 
+	private final ShowService showService;
+
 	@PostMapping
 	public MakeReservationResponse makeReservation(@RequestBody ReservationRequest requestDto) {
 		return reservationFactory.convertReservationToResponse(
-			reservationService.makeReservations(requestDto)
+			reservationService.makeReservations(showService.getShowById(requestDto.showId()), requestDto)
 		);
 	}
 }

--- a/app/src/main/java/com/picketing/www/presentation/controller/show/ShowController.java
+++ b/app/src/main/java/com/picketing/www/presentation/controller/show/ShowController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.picketing.www.business.domain.show.Show;
 import com.picketing.www.business.domain.show.ShowFactory;
+import com.picketing.www.business.domain.show.seat.SeatGradeFactory;
 import com.picketing.www.business.service.show.ShowService;
 import com.picketing.www.business.type.Genre;
 import com.picketing.www.business.type.SubGenre;
@@ -32,6 +33,8 @@ public class ShowController {
 	private final ShowFactory showFactory;
 
 	private final ShowService showService;
+
+	private final SeatGradeFactory seatGradeFactory;
 
 	@GetMapping
 	public Page<ShowMainResponse> getShowListWithPagination(
@@ -60,6 +63,8 @@ public class ShowController {
 		@PathVariable Long showId,
 		@RequestParam(value = "showTime", required = true) String showTime
 	) {
-		return showService.getRemainingSeats(showId, showTime);
+		return seatGradeFactory.convertRemainingSeats(
+			showService.getRemainingSeats(showId, showTime)
+		);
 	}
 }

--- a/app/src/main/java/com/picketing/www/presentation/controller/show/ShowController.java
+++ b/app/src/main/java/com/picketing/www/presentation/controller/show/ShowController.java
@@ -1,5 +1,6 @@
 package com.picketing.www.presentation.controller.show;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -8,6 +9,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -61,7 +63,7 @@ public class ShowController {
 	@GetMapping("/{showId}/seat/remaining-counts")
 	public RemainingSeatsResponse getRemainingSeatCountsByShowAndTime(
 		@PathVariable Long showId,
-		@RequestParam(value = "showTime", required = true) String showTime
+		@RequestParam(value = "showTime", required = true) @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm") LocalDateTime showTime
 	) {
 		return seatGradeFactory.convertRemainingSeats(
 			showService.getRemainingSeats(showId, showTime)

--- a/app/src/main/java/com/picketing/www/presentation/controller/show/ShowController.java
+++ b/app/src/main/java/com/picketing/www/presentation/controller/show/ShowController.java
@@ -63,7 +63,8 @@ public class ShowController {
 	@GetMapping("/{showId}/seat/remaining-counts")
 	public RemainingSeatsResponse getRemainingSeatCountsByShowAndTime(
 		@PathVariable Long showId,
-		@RequestParam(value = "showTime", required = true) @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm") LocalDateTime showTime
+		@RequestParam(value = "showTime", required = true)
+		@DateTimeFormat(pattern = "yyyy-MM-dd HH:mm") LocalDateTime showTime
 	) {
 		return seatGradeFactory.convertRemainingSeats(
 			showService.getRemainingSeats(showId, showTime)

--- a/app/src/main/java/com/picketing/www/presentation/controller/show/ShowController.java
+++ b/app/src/main/java/com/picketing/www/presentation/controller/show/ShowController.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +20,7 @@ import com.picketing.www.business.service.show.ShowService;
 import com.picketing.www.business.type.Genre;
 import com.picketing.www.business.type.SubGenre;
 import com.picketing.www.presentation.dto.response.show.ShowMainResponse;
+import com.picketing.www.presentation.dto.response.show.seat.RemainingSeatsResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -53,4 +55,11 @@ public class ShowController {
 	// 	);
 	// }
 
+	@GetMapping("/{showId}/seat/remaining-counts")
+	public RemainingSeatsResponse getRemainingSeatCountsByShowAndTime(
+		@PathVariable Long showId,
+		@RequestParam(value = "showTime", required = true) String showTime
+	) {
+		return showService.getRemainingSeats(showId, showTime);
+	}
 }

--- a/app/src/main/java/com/picketing/www/presentation/dto/request/reservation/ReservationRequest.java
+++ b/app/src/main/java/com/picketing/www/presentation/dto/request/reservation/ReservationRequest.java
@@ -1,25 +1,34 @@
 package com.picketing.www.presentation.dto.request.reservation;
 
+import java.time.LocalDateTime;
 import java.util.List;
+
+import org.springframework.format.annotation.DateTimeFormat;
 
 import com.picketing.www.business.domain.show.seat.SeatGrade;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import lombok.Builder;
 
 @Builder
 public record ReservationRequest(
+	@Positive
 	Long showId,
-
+	@Positive
 	Long userId,
 
-	String showTime,
-
+	@DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
+	LocalDateTime showTime,
 	List<ReservationSeatRequest> seatGradeList
 ) {
 
 	@Builder
 	public record ReservationSeatRequest(
+		@NotBlank
 		SeatGrade seatGrade,
+		@Min(value = 1, message = "구매할 개수는 1이상의 값이어야 합니다.")
 		int count
 	) {
 	}

--- a/app/src/main/java/com/picketing/www/presentation/dto/response/show/seat/RemainingSeatsResponse.java
+++ b/app/src/main/java/com/picketing/www/presentation/dto/response/show/seat/RemainingSeatsResponse.java
@@ -1,0 +1,18 @@
+package com.picketing.www.presentation.dto.response.show.seat;
+
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record RemainingSeatsResponse(
+	List<RemainingSeatDetail> remainSeats
+) {
+
+	@Builder
+	public record RemainingSeatDetail(
+		String seatGrade,
+		int remainCnt
+	) {
+	}
+}

--- a/app/src/main/java/com/picketing/www/presentation/dto/response/show/seat/ScheduledShowSeatGradeResponse.java
+++ b/app/src/main/java/com/picketing/www/presentation/dto/response/show/seat/ScheduledShowSeatGradeResponse.java
@@ -1,0 +1,18 @@
+package com.picketing.www.presentation.dto.response.show.seat;
+
+import java.time.LocalDateTime;
+
+import com.picketing.www.business.domain.show.Show;
+import com.picketing.www.business.domain.show.seat.SeatGrade;
+
+import lombok.Builder;
+
+@Builder
+public record ScheduledShowSeatGradeResponse(
+	Show show,
+
+	LocalDateTime showTime,
+
+	SeatGrade seatGrade
+) {
+}

--- a/app/src/main/java/com/picketing/www/presentation/dto/response/show/seat/SeatGradeResponse.java
+++ b/app/src/main/java/com/picketing/www/presentation/dto/response/show/seat/SeatGradeResponse.java
@@ -1,0 +1,12 @@
+package com.picketing.www.presentation.dto.response.show.seat;
+
+import lombok.Builder;
+
+@Builder
+public record SeatGradeResponse(
+	String seatGrade,
+
+	int totalCount,
+	Long price
+) {
+}

--- a/app/src/test/java/com/picketing/www/presentation/controller/reservation/ReservationControllerTest.java
+++ b/app/src/test/java/com/picketing/www/presentation/controller/reservation/ReservationControllerTest.java
@@ -1,0 +1,142 @@
+package com.picketing.www.presentation.controller.reservation;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.picketing.www.business.domain.UserFactory;
+import com.picketing.www.business.domain.reservation.ReservationFactory;
+import com.picketing.www.business.domain.reservation.ScheduledShowSeat;
+import com.picketing.www.business.domain.show.Show;
+import com.picketing.www.business.domain.show.ShowFactory;
+import com.picketing.www.business.domain.show.seat.SeatGrade;
+import com.picketing.www.business.service.reservation.ReservationService;
+import com.picketing.www.business.service.show.ShowService;
+import com.picketing.www.business.type.AgeGroup;
+import com.picketing.www.business.type.Genre;
+import com.picketing.www.business.type.SubGenre;
+import com.picketing.www.persistence.repository.UserRepository;
+import com.picketing.www.persistence.repository.reservation.ScheduledShowSeatRepository;
+import com.picketing.www.persistence.repository.show.ShowRepository;
+import com.picketing.www.presentation.dto.request.reservation.ReservationRequest;
+import com.picketing.www.presentation.dto.request.seat.SaveShowRequest;
+import com.picketing.www.presentation.dto.request.user.UserSignUpRequest;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+class ReservationControllerTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@Autowired
+	ReservationService reservationService;
+
+	@Autowired
+	ShowService showService;
+
+	@Autowired
+	ReservationFactory reservationFactory;
+
+	@Autowired
+	ShowRepository showRepository;
+
+	@Autowired
+	ShowFactory showFactory;
+
+	@Autowired
+	UserRepository userRepository;
+
+	@Autowired
+	UserFactory userFactory;
+
+	@Autowired
+	ScheduledShowSeatRepository scheduledShowSeatRepository;
+
+	protected MockHttpSession session;
+
+	@Nested
+	@DisplayName("예약 생성")
+	class MakeReservation {
+
+		@BeforeEach
+		public void setSession() throws Exception {
+			UserSignUpRequest userSignUpRequest = new UserSignUpRequest(
+				"test@email.com", "password1234@"
+			);
+			userRepository.save(userFactory.create(userSignUpRequest));
+			session = new MockHttpSession();
+			session.setAttribute("login_user", 1L);
+		}
+
+		@Test
+		@DisplayName("정상적으로 예약 (예매) 생성")
+		void success() throws Exception {
+			// given
+			SaveShowRequest saveShowRequest = new SaveShowRequest(
+				"찰리푸스 내한 공연",
+				Genre.CONCERT,
+				SubGenre.FOREIGN,
+				LocalDate.of(2023, 10, 20),
+				LocalDate.of(2023, 10, 22),
+				"KSPO DOME",
+				110L,
+				0L,
+				AgeGroup.FOURTEEN,
+				"찰리푸스 내한 공연 - 서울",
+				true,
+				1L
+			);
+
+			Show show = showRepository.save(showFactory.createShow(saveShowRequest));
+			ScheduledShowSeat scheduledShowSeat = new ScheduledShowSeat(show, LocalDateTime.of(2023, 10, 20, 18, 00),
+				SeatGrade.VIP);
+
+			scheduledShowSeatRepository.save(scheduledShowSeat);
+
+			// when
+			ReservationRequest reservationRequest = new ReservationRequest(
+				1L, 1L,
+				LocalDateTime.of(2023, 10, 20, 18, 00),
+				List.of(new ReservationRequest.ReservationSeatRequest(
+					SeatGrade.VIP, 5
+				))
+			);
+
+			// then
+			mockMvc.perform(MockMvcRequestBuilders
+					.post("/api/reservation")
+					.session(session)
+					.accept(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsBytes(reservationRequest))
+					.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andDo(print())
+				.andExpect(status().isOk());
+
+		}
+	}
+
+}


### PR DESCRIPTION
## 관련된 이슈 번호
- issue : #91 

## 변경사항 (할 일)
- [X] 잔여 좌석 조회 API 기능 개발
    - [X] 조회 시점에서 예약이 완료된 좌석을 제외한 잔여 좌석의 개수 리스트를 조회하는 기능을 구현합니다
- [ ] 동시성에 대한 고려
    - [x] Transactional
    - [ ] 이것 말고 다른 방법은 없을지 고려해서 코드 작성 

## 추가 점검사항
- [ ] test case
- [ ] document
