### PR TITLE
[Feature] 비관적 락을 이용하여 동시성 제어

### DIFF
--- a/app/src/main/java/com/picketing/www/business/domain/reservation/ReservationFactory.java
+++ b/app/src/main/java/com/picketing/www/business/domain/reservation/ReservationFactory.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
 import com.picketing.www.business.domain.User;
+import com.picketing.www.business.domain.show.seat.SeatGrade;
 import com.picketing.www.presentation.dto.response.reservation.MakeReservationResponse;
 
 @Component
@@ -34,5 +35,9 @@ public class ReservationFactory {
 			.user(user)
 			.showSeat(showSeat)
 			.build();
+	}
+
+	public SeatGrade convertShowSeatGradeByReservation(Reservation reservation) {
+		return reservation.getShowSeat().getSeatGrade();
 	}
 }

--- a/app/src/main/java/com/picketing/www/business/service/reservation/ReservationService.java
+++ b/app/src/main/java/com/picketing/www/business/service/reservation/ReservationService.java
@@ -44,13 +44,14 @@ public class ReservationService {
 
 	private final Logger logger = LoggerFactory.getLogger(ReservationService.class);
 
+	@Transactional
 	public List<Reservation> makeReservations(Show show, ReservationRequest request) {
 
 		User user = userService.get(request.userId());
 
 		LocalDateTime showTime = request.showTime();
 
-		List<ReservationSeatRequest> seats = request.seatGradeList();
+		List<ReservationSeatRequest> seats = request.reservationSeatRequests();
 
 		return makeReservations(user, show, showTime, seats);
 	}

--- a/app/src/main/java/com/picketing/www/business/service/reservation/ReservationService.java
+++ b/app/src/main/java/com/picketing/www/business/service/reservation/ReservationService.java
@@ -4,10 +4,15 @@ import static com.picketing.www.presentation.dto.request.reservation.Reservation
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.picketing.www.application.exception.CustomException;
 import com.picketing.www.application.exception.ErrorCode;
@@ -21,9 +26,10 @@ import com.picketing.www.business.service.user.UserService;
 import com.picketing.www.persistence.repository.reservation.ReservationRepository;
 import com.picketing.www.presentation.dto.request.reservation.ReservationRequest;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ReservationService {
@@ -36,41 +42,58 @@ public class ReservationService {
 
 	private final ReservationFactory reservationFactory;
 
+	private final Logger logger = LoggerFactory.getLogger(ReservationService.class);
+
 	public List<Reservation> makeReservations(Show show, ReservationRequest request) {
 
 		User user = userService.get(request.userId());
 
 		LocalDateTime showTime = request.showTime();
 
-        List<ReservationSeatRequest> seats = request.seatGradeList();
+		List<ReservationSeatRequest> seats = request.seatGradeList();
 
-        return makeReservations(user, show, showTime, seats);
+		return makeReservations(user, show, showTime, seats);
 	}
 
 	@Transactional
-    public List<Reservation> makeReservations(User user, Show show, LocalDateTime showTime, List<ReservationSeatRequest> seats ) {
+	public List<Reservation> makeReservations(User user, Show show, LocalDateTime showTime,
+		List<ReservationSeatRequest> seats) {
 
-        if (!isBookable(show, showTime, seats)) {
-            throw new CustomException(ErrorCode.ALREADY_RESERVED);
-        }
+		// 예약 정보를 가지고 오고 -> 추가하는 과정에서 동시성 문제가 발생
+		List<List<Reservation>> reservationList = seats.stream()
+			.map(
+				seat -> reservationRepository.findByShowSeatWithPessimisticLock(
+					scheduledShowSeatService.getScheduledShowSeat(show, showTime, seat.seatGrade()))
+			).toList();
 
-        List<Reservation> reservations = seats
-                .stream()
-                .flatMap(seatRequest -> makeReservationPerCount(user, show, showTime, seatRequest).stream())
-                .collect(Collectors.toList());
+		Map<SeatGrade, Integer> reservedSeatCountMap = new ConcurrentHashMap<>();
+		reservationList.forEach((reservation -> {
+			Reservation current = reservation.get(0);
+			SeatGrade currentSeat = reservationFactory.convertShowSeatGradeByReservation(current);
+			int reservedCount = reservation.size();
+			reservedSeatCountMap.put(currentSeat, reservedCount);
+		}));
 
-        return reservationRepository.saveAll(reservations);
+		if (!isBookable(reservedSeatCountMap, seats)) {
+			throw new CustomException(ErrorCode.ALREADY_RESERVED);
+		}
+
+		List<Reservation> reservations = seats
+			.stream()
+			.flatMap(seatRequest -> makeReservationPerCount(user, show, showTime, seatRequest).stream())
+			.collect(Collectors.toList());
+
+		return reservationRepository.saveAll(reservations);
 	}
 
-	private boolean isBookable(Show show, LocalDateTime showTime, List<ReservationSeatRequest> seatRequestList) {
+	private boolean isBookable(Map<SeatGrade, Integer> map, List<ReservationSeatRequest> seatRequestList) {
 		return seatRequestList.stream()
 			.allMatch(seatRequest -> {
 				SeatGrade currentSeatGrade = seatRequest.seatGrade();
-				long reservedCount = countReservationsByShowSeat(
-					scheduledShowSeatService.getScheduledShowSeat(show, showTime,
-						currentSeatGrade));
+				Integer purchaseCount = seatRequest.count();
+				Integer reservedCount = map.get(currentSeatGrade);
 
-				return ((currentSeatGrade.getCount() - reservedCount) - seatRequest.count()) >= 0;
+				return ((currentSeatGrade.getCount() - reservedCount) - purchaseCount >= 0);
 			});
 	}
 

--- a/app/src/main/java/com/picketing/www/persistence/repository/reservation/ReservationRepository.java
+++ b/app/src/main/java/com/picketing/www/persistence/repository/reservation/ReservationRepository.java
@@ -3,10 +3,17 @@ package com.picketing.www.persistence.repository.reservation;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.picketing.www.business.domain.reservation.Reservation;
 import com.picketing.www.business.domain.reservation.ScheduledShowSeat;
+
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
@@ -14,4 +21,13 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 	Long countReservationsByShowSeat(ScheduledShowSeat scheduledShowSeat);
 
 	List<Reservation> findAllByShowSeat(ScheduledShowSeat scheduledShowSeat);
+
+	// 예약 정보 조회 시 베타락을 건다
+	@Query(value = "select r from Reservation r where r.showSeat = :scheduledShowSeat")
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@QueryHints({
+		@QueryHint(name = "javax.persistence.lock.timeout", value = "1000")
+	})
+	List<Reservation> findByShowSeatWithPessimisticLock(
+		@Param("scheduledShowSeat") ScheduledShowSeat scheduledShowSeat);
 }

--- a/app/src/main/java/com/picketing/www/persistence/repository/reservation/ReservationRepository.java
+++ b/app/src/main/java/com/picketing/www/persistence/repository/reservation/ReservationRepository.java
@@ -26,7 +26,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 	@Query(value = "select r from Reservation r where r.showSeat = :scheduledShowSeat")
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@QueryHints({
-		@QueryHint(name = "javax.persistence.lock.timeout", value = "1000")
+		@QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000")
 	})
 	List<Reservation> findByShowSeatWithPessimisticLock(
 		@Param("scheduledShowSeat") ScheduledShowSeat scheduledShowSeat);

--- a/app/src/main/java/com/picketing/www/presentation/controller/show/ShowController.java
+++ b/app/src/main/java/com/picketing/www/presentation/controller/show/ShowController.java
@@ -64,7 +64,7 @@ public class ShowController {
 	public RemainingSeatsResponse getRemainingSeatCountsByShowAndTime(
 		@PathVariable Long showId,
 		@RequestParam(value = "showTime", required = true)
-		@DateTimeFormat(pattern = "yyyy-MM-dd HH:mm") LocalDateTime showTime
+		@DateTimeFormat(pattern = "yyyy-MM-ddTHH:mm") LocalDateTime showTime
 	) {
 		return seatGradeFactory.convertRemainingSeats(
 			showService.getRemainingSeats(showId, showTime)

--- a/app/src/main/java/com/picketing/www/presentation/dto/request/reservation/ReservationRequest.java
+++ b/app/src/main/java/com/picketing/www/presentation/dto/request/reservation/ReservationRequest.java
@@ -19,9 +19,9 @@ public record ReservationRequest(
 	@Positive
 	Long userId,
 
-	@DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
+	@DateTimeFormat(pattern = "yyyy-MM-ddTHH:mm")
 	LocalDateTime showTime,
-	List<ReservationSeatRequest> seatGradeList
+	List<ReservationSeatRequest> reservationSeatRequests
 ) {
 
 	@Builder


### PR DESCRIPTION
## 관련된 이슈 번호
- issue : #100

## 변경사항 (할 일)
- 예매 시, 비관적 락을 이용하여 동시 예매에 대한 동시성 제어를 합니다.
    - `Reservation` 조회 시 베타락을 이용하여 다른 트랜잭션에서 읽기 및 쓰기가 모두 불가능하도록 합니다.

## 추가 점검사항
- [ ] test case
